### PR TITLE
Fix access to file time on non-apple unix systems

### DIFF
--- a/shaderset.cpp
+++ b/shaderset.cpp
@@ -53,7 +53,11 @@ static uint64_t GetShaderFileTimestamp(const char* filename)
         return 0;
     }
 
+#ifdef __APPLE__
     timestamp = fileStat.st_mtimespec.tv_sec;
+#else
+    timestamp = fileStat.st_mtime;
+#endif
 #endif
 
     return timestamp;


### PR DESCRIPTION
On most linux systems and freebsd the exact field would be `st_mtim.tv_sec` but they all define an `st_mtime` macro for backwards compatiblity so by using `st_mtime` it should work on those systems in addition to some ancient systems. I’m happy to change it to the former if you prefer that. On freebsd `st_mtimespec` works too but is just a macro for `st_mtim`, so maybe the check could also be changed to include that in the first case but I don’t see any benefit to that.