### PR TITLE
support for multiple shader stages in one file

### DIFF
--- a/shaderset.cpp
+++ b/shaderset.cpp
@@ -163,6 +163,16 @@ void ShaderSet::UpdatePrograms()
         // the #line directive also allows specifying a "file name" number, which makes it possible to identify which file the error came from.
         std::string version = "#version " + mVersion + "\n";
         
+        std::string defines;
+        switch (shader->first.Type) {
+        case GL_VERTEX_SHADER:          defines += "#define VERTEX_SHADER\n";             break;
+        case GL_FRAGMENT_SHADER:        defines += "#define FRAGMENT_SHADER\n";           break;
+        case GL_GEOMETRY_SHADER:        defines += "#define GEOMETRY_SHADER\n";           break;
+        case GL_TESS_CONTROL_SHADER:    defines += "#define TESS_CONTROL_SHADER\n";       break;
+        case GL_TESS_EVALUATION_SHADER: defines += "#define TESS_EVALUATION_SHADER\n";    break;
+        case GL_COMPUTE_SHADER:         defines += "#define COMPUTE_SHADER\n";            break;
+        }
+
         std::string preamble_hash = std::to_string((int32_t)std::hash<std::string>()("preamble") & 0x7FFFFFFF);
         std::string premable = "#line 1 " + preamble_hash + "\n" + 
                                mPreamble + "\n";
@@ -173,11 +183,13 @@ void ShaderSet::UpdatePrograms()
 
         const char* strings[] = {
             version.c_str(),
+            defines.c_str(),
             premable.c_str(),
             source.c_str()
         };
         GLint lengths[] = {
             (GLint)version.length(),
+            (GLint)defines.length(),
             (GLint)premable.length(),
             (GLint)source.length()
         };
@@ -350,3 +362,14 @@ GLuint* ShaderSet::AddProgramFromExts(const std::vector<std::string>& shaders)
 
     return AddProgram(typedShaders);
 }
+
+GLuint* ShaderSet::AddProgramFromCombinedFile(const std::string &filename, const std::vector<GLenum> &shaderTypes)
+{
+    std::vector<std::pair<std::string, GLenum>> typedShaders;
+
+    for (auto type: shaderTypes)
+        typedShaders.emplace_back(filename, type);
+
+    return AddProgram(typedShaders);
+}
+

--- a/shaderset.h
+++ b/shaderset.h
@@ -87,4 +87,6 @@ public:
     // eg: AddProgramFromExts({"foo.vert", "bar.frag"});
     // To be const-correct, this should maybe return "const GLuint*". I'm trusting you not to write to that pointer.
     GLuint* AddProgramFromExts(const std::vector<std::string>& shaders);
+
+    GLuint* AddProgramFromCombinedFile(const std::string &filename, const std::vector<GLenum> &shaderTypes);
 };


### PR DESCRIPTION
See Issue https://github.com/nlguillemot/ShaderSet/issues/3 for discussion

The new function can be used like this:
  `AddProgramFromCombinedFile("test.glsl", { GL_VERTEX_SHADER, GL_FRAGMENT_SHADER });`

The glsl File may contain different sections for the shader stages, and also common `#defines`:

```glsl
// Read by both GLSL and C compiler
#define TICKS_LOC 0
#define SPEED_LOC 1

#ifdef GL_core_profile
// Read by the GLSL compiler only
#define M_PI  3.14159265359
layout(location = TICKS_LOC ) uniform float ticks;
layout(location = SPEED_LOC )    uniform float speed;
#endif

#ifdef VERTEX_SHADER
...
void main(void)
...
#endif

#ifdef FRAGMENT_SHADER
...
#endif

```

ShaderSet just inserts corresponding #defines for each shader type.
The glsl file can also be included as a header in your C-Program to define layout locations.
